### PR TITLE
Escape special regex characters for better matching

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -33,7 +33,7 @@ module.exports = function( options, callback )
             }
 
             var css = 'url("' + datauriContent + '");';
-            result = result.replace( new RegExp( "url\\(\\s?[\"']?(" + inline.escapeCharClass(args.src) + ")[\"']?\\s?\\);", "g" ), css );
+            result = result.replace( new RegExp( "url\\(\\s?[\"']?(" + inline.escapeSpecialChars(args.src) + ")[\"']?\\s?\\);", "g" ), css );
             return( callback( null ) );
         } );
     };
@@ -41,7 +41,7 @@ module.exports = function( options, callback )
     var rebase = function( src )
     {
         var css = 'url("' + path.join( settings.rebaseRelativeTo, src ).replace( /\\/g, "/" ) + '");';
-        result = result.replace( new RegExp( "url\\(\\s?[\"']?(" + inline.escapeCharClass(src) + ")[\"']?\\s?\\);", "g" ), css );
+        result = result.replace( new RegExp( "url\\(\\s?[\"']?(" + inline.escapeSpecialChars(src) + ")[\"']?\\s?\\);", "g" ), css );
     };
 
     var result = settings.fileContent;

--- a/src/css.js
+++ b/src/css.js
@@ -33,7 +33,7 @@ module.exports = function( options, callback )
             }
 
             var css = 'url("' + datauriContent + '");';
-            result = result.replace( new RegExp( "url\\(\\s?[\"']?(" + args.src + ")[\"']?\\s?\\);", "g" ), css );
+            result = result.replace( new RegExp( "url\\(\\s?[\"']?(" + inline.escapeCharClass(args.src) + ")[\"']?\\s?\\);", "g" ), css );
             return( callback( null ) );
         } );
     };
@@ -41,7 +41,7 @@ module.exports = function( options, callback )
     var rebase = function( src )
     {
         var css = 'url("' + path.join( settings.rebaseRelativeTo, src ).replace( /\\/g, "/" ) + '");';
-        result = result.replace( new RegExp( "url\\(\\s?[\"']?(" + src + ")[\"']?\\s?\\);", "g" ), css );
+        result = result.replace( new RegExp( "url\\(\\s?[\"']?(" + inline.escapeCharClass(src) + ")[\"']?\\s?\\);", "g" ), css );
     };
 
     var result = settings.fileContent;

--- a/src/html.js
+++ b/src/html.js
@@ -29,7 +29,7 @@ module.exports = function( options, callback )
                 return callback( null );
             }
             var html = '<script' + ( args.attrs ? ' ' + args.attrs : '' ) + '>\n' + js + '\n</script>';
-            result = result.replace( new RegExp( "<script.+?src=[\"'](" + args.src + ")[\"'].*?>\s*<\/script>", "g" ), html );
+            result = result.replace( new RegExp( "<script.+?src=[\"'](" + inline.escapeCharClass(args.src) + ")[\"'].*?>\s*<\/script>", "g" ), html );
             return callback( null );
         } );
     };
@@ -61,7 +61,8 @@ module.exports = function( options, callback )
                     return callback( err );
                 }
                 var html = '<style' + ( args.attrs ? ' ' + args.attrs : '' ) + '>\n' + content + '\n</style>';
-                result = result.replace( new RegExp( "<link.+?href=[\"'](" + args.src + ")[\"'].*?\/?>", "g" ), html );
+                
+                result = result.replace( new RegExp( "<link.+?href=[\"'](" + inline.escapeCharClass(args.src) + ")[\"'].*?\/?>", "g" ), html );
                 return callback( null );
             } );
         } );
@@ -82,7 +83,7 @@ module.exports = function( options, callback )
                 return callback( null );
             }
             var html = '<img' + ( args.attrs ? ' ' + args.attrs : '' ) + ' src="' + datauriContent + '" />';
-            result = result.replace( new RegExp( "<img.+?src=[\"'](" + args.src + ")[\"'].*?\/?\s*?>", "g" ), html );
+            result = result.replace( new RegExp( "<img.+?src=[\"'](" + inline.escapeCharClass(args.src) + ")[\"'].*?\/?\s*?>", "g" ), html );
             return callback( null );
         } );
     };

--- a/src/html.js
+++ b/src/html.js
@@ -29,7 +29,7 @@ module.exports = function( options, callback )
                 return callback( null );
             }
             var html = '<script' + ( args.attrs ? ' ' + args.attrs : '' ) + '>\n' + js + '\n</script>';
-            result = result.replace( new RegExp( "<script.+?src=[\"'](" + inline.escapeCharClass(args.src) + ")[\"'].*?>\s*<\/script>", "g" ), html );
+            result = result.replace( new RegExp( "<script.+?src=[\"'](" + inline.escapeSpecialChars(args.src) + ")[\"'].*?>\s*<\/script>", "g" ), html );
             return callback( null );
         } );
     };
@@ -62,7 +62,7 @@ module.exports = function( options, callback )
                 }
                 var html = '<style' + ( args.attrs ? ' ' + args.attrs : '' ) + '>\n' + content + '\n</style>';
                 
-                result = result.replace( new RegExp( "<link.+?href=[\"'](" + inline.escapeCharClass(args.src) + ")[\"'].*?\/?>", "g" ), html );
+                result = result.replace( new RegExp( "<link.+?href=[\"'](" + inline.escapeSpecialChars(args.src) + ")[\"'].*?\/?>", "g" ), html );
                 return callback( null );
             } );
         } );
@@ -83,7 +83,7 @@ module.exports = function( options, callback )
                 return callback( null );
             }
             var html = '<img' + ( args.attrs ? ' ' + args.attrs : '' ) + ' src="' + datauriContent + '" />';
-            result = result.replace( new RegExp( "<img.+?src=[\"'](" + inline.escapeCharClass(args.src) + ")[\"'].*?\/?\s*?>", "g" ), html );
+            result = result.replace( new RegExp( "<img.+?src=[\"'](" + inline.escapeSpecialChars(args.src) + ")[\"'].*?\/?\s*?>", "g" ), html );
             return callback( null );
         } );
     };

--- a/src/util.js
+++ b/src/util.js
@@ -25,6 +25,20 @@ util.defaults = {
     fileContent: ''
 };
 
+/**
+ * Escape regex character classes of a particular string
+ * 
+ * @example
+ * "http://www.test.com" --> "http:\/\/www\.test\.com"
+ *     
+ * @param  {String} str - string to escape
+ * @return {String} string with character classes escaped
+ */
+util.escapeCharClass = function(str)
+{
+    return str.replace(/(\/|\.|\$|\^|\{|\[|\(|\||\)|\*|\+|\?|\\)/g, '\\$1');
+};
+
 util.isRemotePath = function( url )
 {
     return url.match( /^'?https?:\/\// ) || url.match( /^\/\// );

--- a/src/util.js
+++ b/src/util.js
@@ -26,15 +26,15 @@ util.defaults = {
 };
 
 /**
- * Escape regex character classes of a particular string
+ * Escape special regex characters of a particular string
  * 
  * @example
  * "http://www.test.com" --> "http:\/\/www\.test\.com"
  *     
  * @param  {String} str - string to escape
- * @return {String} string with character classes escaped
+ * @return {String} string with special characters escaped
  */
-util.escapeCharClass = function(str)
+util.escapeSpecialChars = function(str)
 {
     return str.replace(/(\/|\.|\$|\^|\{|\[|\(|\||\)|\*|\+|\?|\\)/g, '\\$1');
 };

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var fs = require('fs');
 var inline = require('../src/inline.js');
+var util = require('../src/util.js');
 
 function normalize(contents) {
     return (process.platform === 'win32' ? contents.replace(/\r\n/g, '\n') : contents);
@@ -276,4 +277,16 @@ describe('css', function() {
             }
         );
     });
+});
+
+describe("util", function() {
+
+    describe("#escapeSpecialChars", function() {
+        it("should escape special regex characters in a string", function() {
+            var input = 'http://fonts.googleapis.com/css?family=Open+Sans';
+            var output = 'http:\/\/fonts\.googleapis\.com\/css\?family=Open\+Sans';
+            assert.equal(input, output);
+        });
+    });
+
 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -283,9 +283,16 @@ describe("util", function() {
 
     describe("#escapeSpecialChars", function() {
         it("should escape special regex characters in a string", function() {
-            var input = 'http://fonts.googleapis.com/css?family=Open+Sans';
-            var output = 'http:\/\/fonts\.googleapis\.com\/css\?family=Open\+Sans';
-            assert.equal(input, output);
+            
+            var str = 'http://fonts.googleapis.com/css?family=Open+Sans';
+            var expected = 'http:\\/\\/fonts\\.googleapis\\.com\\/css\\?family=Open\\+Sans';
+            
+            var result = util.escapeSpecialChars(str);
+            var regex = new RegExp(result, "g");
+
+            assert.equal(result, expected);
+            assert.equal(str.match(regex).length, 1);
+
         });
     });
 


### PR DESCRIPTION
If a url contains special regex characters, it does not match and get inlined. 

For instance, the url below contains the `?` operator and should be escaped. 
ex. http://fonts.googleapis.com/css?family=Lato:300,400,700,900
