### PR TITLE
Prevent replacement pattern matches in assets.

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -33,7 +33,8 @@ module.exports = function( options, callback )
             }
 
             var css = 'url("' + datauriContent + '");';
-            result = result.replace( new RegExp( "url\\(\\s?[\"']?(" + args.src + ")[\"']?\\s?\\);", "g" ), css );
+            result = result.replace( new RegExp( "url\\(\\s?[\"']?(" + args.src + ")[\"']?\\s?\\);", "g" ),
+                function( ) { return css; } );
             return( callback( null ) );
         } );
     };
@@ -41,7 +42,8 @@ module.exports = function( options, callback )
     var rebase = function( src )
     {
         var css = 'url("' + path.join( settings.rebaseRelativeTo, src ).replace( /\\/g, "/" ) + '");';
-        result = result.replace( new RegExp( "url\\(\\s?[\"']?(" + src + ")[\"']?\\s?\\);", "g" ), css );
+        result = result.replace( new RegExp( "url\\(\\s?[\"']?(" + src + ")[\"']?\\s?\\);", "g" ),
+            function( ) { return css; } );
     };
 
     var result = settings.fileContent;

--- a/src/html.js
+++ b/src/html.js
@@ -29,7 +29,8 @@ module.exports = function( options, callback )
                 return callback( null );
             }
             var html = '<script' + ( args.attrs ? ' ' + args.attrs : '' ) + '>\n' + js + '\n</script>';
-            result = result.replace( new RegExp( "<script.+?src=[\"'](" + args.src + ")[\"'].*?>\s*<\/script>", "g" ), html );
+            result = result.replace( new RegExp( "<script.+?src=[\"'](" + args.src + ")[\"'].*?>\s*<\/script>", "g" ),
+                function( ) { return html; } );
             return callback( null );
         } );
     };

--- a/src/html.js
+++ b/src/html.js
@@ -62,7 +62,8 @@ module.exports = function( options, callback )
                     return callback( err );
                 }
                 var html = '<style' + ( args.attrs ? ' ' + args.attrs : '' ) + '>\n' + content + '\n</style>';
-                result = result.replace( new RegExp( "<link.+?href=[\"'](" + args.src + ")[\"'].*?\/?>", "g" ), html );
+                result = result.replace( new RegExp( "<link.+?href=[\"'](" + args.src + ")[\"'].*?\/?>", "g" ),
+                    function( ) { return html; } );
                 return callback( null );
             } );
         } );
@@ -83,7 +84,8 @@ module.exports = function( options, callback )
                 return callback( null );
             }
             var html = '<img' + ( args.attrs ? ' ' + args.attrs : '' ) + ' src="' + datauriContent + '" />';
-            result = result.replace( new RegExp( "<img.+?src=[\"'](" + args.src + ")[\"'].*?\/?\s*?>", "g" ), html );
+            result = result.replace( new RegExp( "<img.+?src=[\"'](" + args.src + ")[\"'].*?\/?\s*?>", "g" ),
+                function( ) { return html; } );
             return callback( null );
         } );
     };

--- a/test/cases/assets/regex.js
+++ b/test/cases/assets/regex.js
@@ -1,0 +1,2 @@
+var $=1;
+if(2>$&&false)return;

--- a/test/cases/script-regex-escape.html
+++ b/test/cases/script-regex-escape.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>test</title>
+    <script src="assets/regex.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/spec.js
+++ b/test/spec.js
@@ -246,6 +246,18 @@ describe('html', function() {
             }
         );
     });
+
+    it('should properly escape regex vars before calling replace()', function(done) {
+        inline.html({
+                fileContent: readFile('test/cases/script-regex-escape.html'),
+                relativeTo: 'test/cases/'
+            },
+            function(err, result) {
+                assert.equal(result.indexOf('$&') > -1, true);
+                done();
+            }
+        );
+    });
 });
 
 describe('css', function() {


### PR DESCRIPTION
Reproduce: Try to minimize a document that has a `<script>` tag that points to the following code:

```
var $=1;if(2>$&&true)return;
```

You'll get an error, because of [this line](https://github.com/jrit/web-resource-inliner/blob/master/src/html.js#L32). The `$&` is treated as a reference to the match in the regex. The fix is to pass a function that returns the string, which does not have pattern matches interpreted.
