### PR TITLE
Add License to Package File and Upgrade UglifyJS Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "web-resource-inliner",
   "description": "Inlines img, script and link tags into the same file.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "keywords": [
     "inline",
     "js",
@@ -16,6 +16,7 @@
     "html",
     "datauri"
   ],
+  "license": "MIT",
   "main": "src/inline.js",
   "repository": {
     "type": "git",
@@ -35,7 +36,7 @@
     "cli-color": "^0.3.2",
     "datauri": "~0.2.0",
     "request": "^2.49.0",
-    "uglify-js": "2.4.1",
+    "uglify-js": "^2.4.1",
     "xtend": "^4.0.0"
   },
   "scripts": {


### PR DESCRIPTION
This PR adds the license to the package json and makes `uglify-js` allow versions >= 2.4.1 to account for the identified security issue here: https://nodesecurity.io/advisories/uglifyjs_incorrectly_handles_non-boolean_comparisons
