### PR TITLE
Make sure to strip the value of `data-inline(-ignore)` attributes if they exist

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -15,8 +15,8 @@ module.exports = function( options, callback )
     function replaceInlineAttribute( string )
     {
         return string
-            .replace( new RegExp( " " + settings.inlineAttribute + "-ignore", "gi" ), "" )
-            .replace( new RegExp( " " + settings.inlineAttribute, "gi" ), "" );
+            .replace( new RegExp( " " + settings.inlineAttribute + "-ignore" + inline.attrValueExpression, "gi" ), "" )
+            .replace( new RegExp( " " + settings.inlineAttribute + inline.attrValueExpression, "gi" ), "" );
     }
 
     var replaceScript = function( callback )

--- a/src/util.js
+++ b/src/util.js
@@ -24,6 +24,8 @@ util.defaults = {
     fileContent: ""
 };
 
+util.attrValueExpression = "(=[\"']([^\"']+?)[\"'])?";
+
 /**
  * Escape special regex characters of a particular string
  *
@@ -58,8 +60,8 @@ util.getAttrs = function( tagMarkup, settings )
             .replace( /^<[^\s>]*/, "" )
             .replace( /\/?>/, "" )
             .replace( />?\s?<\/[^>]*>$/, "" )
-            .replace( new RegExp( settings.inlineAttribute + "-ignore", "gi" ), "" )
-            .replace( new RegExp( settings.inlineAttribute, "gi" ), "" );
+            .replace( new RegExp( settings.inlineAttribute + "-ignore" + util.attrValueExpression, "gi" ), "" )
+            .replace( new RegExp( settings.inlineAttribute + util.attrValueExpression, "gi" ), "" );
 
         if( tag === "<script" || tag === "<img" )
         {

--- a/test/cases/img-opt-in.html
+++ b/test/cases/img-opt-in.html
@@ -5,6 +5,7 @@
 </head>
 <body>
     <img src="assets/icon.png" data-inline />
+    <img src="assets/icon.png" data-inline="data-inline" />
     <img src="assets/icon.png" />
     <img src="assets/not-the-icon.png" />
 </body>

--- a/test/cases/img-opt-in_out.html
+++ b/test/cases/img-opt-in_out.html
@@ -6,6 +6,7 @@
 <body>
     <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC" />
     <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC" />
+    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC" />
     <img src="assets/not-the-icon.png" />
 </body>
 </html>


### PR DESCRIPTION
Some html preprocessors like jade output `data-inline` as `data-inline="data-inline"` or `data-inline=""`.

With the current regexps this results in things like `<style ="">` being left behind.
