### PR TITLE
Move callback outside of try.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -134,12 +134,12 @@ util.getTextReplacement = function( src, relativeTo, callback )
         try
         {
             var replacement = util.getInlineFileContents( src, relativeTo );
-            return callback( null, replacement );
         }
         catch( err )
         {
             return callback( err );
         }
+        return callback( null, replacement );
     }
 };
 


### PR DESCRIPTION
Leaving the callback inside try leads to any programmer error inside the callback being captured
and the callback re-called with that as an error.

In normal nodejs flow this may turn into an infinite loop.
In promisified flow this leads to cryptic errors about callback being called twice.
