### PR TITLE
Option to adjust HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ If uglify is assigned `true`, JavaScript file will be minified before inlined.
 #### `strict`, Boolean, default `false`
 When strict is `true`, a missing resource will cause the inliner to halt and return an error in the callback. The default behavior is to log a warning to the console and continue inlining with the available resources, which is more similar to how a web page behaves.
 
+#### `requestTransform`, Function, default `undefined`
+Allows to adjust issued requests. E.g., add authentication tokens to requested URLs. The function is called with the request options object as its parameter. It can modify this object or return a new one. See [the list of available options](https://www.npmjs.com/package/request#request-options-callback).
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Run tests with `npm test`.

--- a/src/css.js
+++ b/src/css.js
@@ -20,7 +20,7 @@ module.exports = function( options, callback )
             return callback( null ); // Skip
         }
 
-        inline.getFileReplacement( args.src, settings.relativeTo, function( err, datauriContent )
+        inline.getFileReplacement( args.src, settings, function( err, datauriContent )
         {
             if( err )
             {

--- a/src/html.js
+++ b/src/html.js
@@ -25,7 +25,7 @@ module.exports = function( options, callback )
 
         args.element = replaceInlineAttribute( args.element );
 
-        inline.getTextReplacement( args.src, settings.relativeTo, function( err, content )
+        inline.getTextReplacement( args.src, settings, function( err, content )
         {
             if( err )
             {
@@ -49,7 +49,7 @@ module.exports = function( options, callback )
 
         args.element = replaceInlineAttribute( args.element );
 
-        inline.getTextReplacement( args.src, settings.relativeTo, function( err, content )
+        inline.getTextReplacement( args.src, settings, function( err, content )
         {
             if( err )
             {
@@ -85,7 +85,7 @@ module.exports = function( options, callback )
 
         args.element = replaceInlineAttribute( args.element );
 
-        inline.getFileReplacement( args.src, settings.relativeTo, function( err, datauriContent )
+        inline.getFileReplacement( args.src, settings, function( err, datauriContent )
         {
             if( err )
             {

--- a/test/spec.js
+++ b/test/spec.js
@@ -426,6 +426,26 @@ describe( "html", function()
             } );
         } );
 
+        it( "should apply the requestTransform option", function( done ) {
+            fauxJax.on( "request", function( request )
+            {
+                assert( request.requestURL.indexOf( "foo=bar" ) !== -1 );
+            } );
+            inline.html( {
+                fileContent: "<img src=\"assets/icon.png\"><img src=\"assets/icon.png?a=1\">",
+                relativeTo: baseUrl,
+                scripts: true,
+                links: true,
+                images: true,
+                requestTransform: function(options)
+                {
+                    options.qs = {
+                        foo: "bar"
+                    };
+                }
+            }, done );
+        } );
+
     } );
 } );
 


### PR DESCRIPTION
#### `requestTransform`, Function, default `undefined`

Allows to adjust issued requests. E.g., add authentication tokens to requested URLs. The function is called with the request options object as its parameter. It can modify this object or return a new one. See [the list of available options](https://www.npmjs.com/package/request#request-options-callback).
