### PR TITLE
Return the correct status code on http error

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -94,7 +94,7 @@ util.getRemote = function( uri, callback, toDataUri )
             }
             else if( response.statusCode !== 200 )
             {
-                return callback( new Error( uri + " returned http " + response.code ) );
+                return callback( new Error( uri + " returned http " + response.statusCode ) );
             }
 
             if( toDataUri )

--- a/test/spec.js
+++ b/test/spec.js
@@ -284,7 +284,7 @@ describe( "html", function()
             },
             function( err, result )
             {
-                assert.equal( !!err, true );
+                assert.equal( err.message, "https://raw.githubusercontent.com/not-a-file.css returned http 400" );
                 done();
             }
         );


### PR DESCRIPTION
Previously the wrong value was used when a http error was encountered and the status was reported as 'undefined'.

PR includes a failing test and an fix.
