### PR TITLE
Allow gzip files to be decoded

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -84,7 +84,8 @@ util.getRemote = function( uri, callback, toDataUri )
     request(
         {
             uri: uri,
-            encoding: toDataUri ? "binary" : ""
+            encoding: toDataUri ? "binary" : "",
+            gzip: true
         },
         function( err, response, body )
         {


### PR DESCRIPTION
This has no side effects, if the file is not gzip encoded, this does nothing, but if it is, it properly decodes it before passing back the contents/body
