### PR TITLE
buffer.toString() encoding fix for nodejs 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: node_js
 node_js:
   - "4"
   - "6"
+  - "7"
+  - "8"
 before_script:
   - npm install -g grunt-cli

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# web-resource-inliner[![build status](https://secure.travis-ci.org/jrit/web-resource-inliner.png)](http://travis-ci.org/jrit/web-resource-inliner)
+# web-resource-inliner [![build status](https://api.travis-ci.org/jrit/web-resource-inliner.svg)](http://travis-ci.org/jrit/web-resource-inliner)
 
 Brings externally referenced resources, such as js, css and images, into a single file.
 

--- a/src/util.js
+++ b/src/util.js
@@ -86,7 +86,7 @@ function getRemote( uri, settings, callback, toDataUri )
 
     var requestOptions = {
         uri: uri,
-        encoding: toDataUri ? "binary" : "",
+        encoding: toDataUri && "binary",
         gzip: true
     };
 


### PR DESCRIPTION
In Node.js 8 you can't do buffer.toString(''), it will fail with "unknown encoding".

Current unit-tests are enough to reproduce it, here is just a fix.