### PR TITLE
Support file: protocol by switching to Jetta (with tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Describes the path relationship between CSS content and the context it will be l
 When strict is `true`, a missing resource will cause the inliner to halt and return an error in the callback. The default behavior is to log a warning to the console and continue inlining with the available resources, which is more similar to how a web page behaves.
 
 #### `requestTransform`, Function, default `undefined`
-Allows to adjust issued requests. E.g., add authentication tokens to requested URLs. The function is called with the request options object as its parameter. It can modify this object or return a new one. See [the list of available options](https://www.npmjs.com/package/request#request-options-callback).
+Allows to adjust issued requests. E.g., add authentication tokens to requested URLs. The function is called with the request options object as its parameter. It can modify this object or return a new one. See [the list of available options](https://github.com/AltusAero/jetta/blob/master/docs/request.md).
 
 #### `scriptTransform`, Function( content, callback ), default `undefined`
 Allows to make changes to scripts before they are inlined, such as minifying. Callback is standard node error first, second argument is transformed value.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,6 @@
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
     },
-    "ajv": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
-      "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
-      }
-    },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
@@ -57,16 +46,6 @@
         "sprintf-js": "1.0.3"
       }
     },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "async": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
@@ -75,43 +54,11 @@
         "lodash": "4.17.4"
       }
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
     },
     "bowser": {
       "version": "1.7.3",
@@ -141,11 +88,6 @@
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true,
       "optional": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
       "version": "0.1.3",
@@ -182,19 +124,6 @@
         "wordwrap": "1.0.0"
       }
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
-    "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
-    },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
@@ -214,32 +143,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
     },
     "datauri": {
       "version": "1.0.5",
@@ -272,11 +175,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
       "version": "3.2.0",
@@ -313,15 +211,6 @@
       "requires": {
         "dom-serializer": "0.1.0",
         "domelementtype": "1.3.0"
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
       }
     },
     "entities": {
@@ -365,21 +254,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
-    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -405,34 +279,11 @@
       "integrity": "sha1-6VF4TXkJUSfTcTApqwY/QIGMoq4=",
       "dev": true
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
     },
     "glob": {
       "version": "5.0.15",
@@ -488,20 +339,6 @@
         }
       }
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "requires": {
-        "ajv": "5.2.2",
-        "har-schema": "2.0.0"
-      }
-    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -516,27 +353,11 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.0.2"
-      }
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "htmlparser2": {
       "version": "3.9.2",
@@ -549,16 +370,6 @@
         "entities": "1.1.1",
         "inherits": "2.0.3",
         "readable-stream": "2.3.3"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
       }
     },
     "image-size": {
@@ -587,11 +398,6 @@
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -602,11 +408,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul": {
       "version": "0.4.5",
@@ -670,56 +471,11 @@
         }
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "0.0.0"
-      }
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
     },
     "kind-of": {
       "version": "3.2.2",
@@ -840,12 +596,14 @@
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "dev": true,
       "requires": {
         "mime-db": "1.30.0"
       }
@@ -956,11 +714,6 @@
         "abbrev": "1.0.9"
       }
     },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1000,11 +753,6 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -1015,16 +763,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
-    "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "readable-stream": {
       "version": "2.3.3",
@@ -1045,35 +783,6 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
-    },
-    "request": {
-      "version": "2.82.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.82.0.tgz",
-      "integrity": "sha512-/QWqfmyTfQ4OYs6EhB1h2wQsX9ZxbuNePCvCm0Mdz/mxw73mjdg0D4QdIl0TQBFs35CZmMXLjk0iCGK395CUDg==",
-      "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
-      }
     },
     "resolve": {
       "version": "1.1.7",
@@ -1101,14 +810,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
-    "sntp": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
     "source-map": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
@@ -1125,21 +826,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      }
-    },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
@@ -1147,11 +833,6 @@
       "requires": {
         "safe-buffer": "5.1.1"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -1165,28 +846,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-    },
-    "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "requires": {
-        "punycode": "1.4.1"
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -1236,25 +895,10 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-    },
     "valid-data-url": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-0.1.4.tgz",
       "integrity": "sha512-p3bCVl3Vrz42TV37a1OjagyLLd6qQAXBDWarIazuo7NQzCt8Kw8ZZwSAbUVPGlz5ubgbgJmgT0KRjLeCFNrfoQ=="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      }
     },
     "which": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,6 +399,12 @@
         "writable-window-method": "1.0.3"
       }
     },
+    "file-url": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/file-url/-/file-url-2.0.2.tgz",
+      "integrity": "sha1-6VF4TXkJUSfTcTApqwY/QIGMoq4=",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -640,6 +646,11 @@
           }
         }
       }
+    },
+    "jetta": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/jetta/-/jetta-1.1.3.tgz",
+      "integrity": "sha512-aoFpw/mYlBpVMvBpkmafyO0VYOJkNk7A9NWYKiwMlSYcmEOMJZYvvoLdcw1yxta5HScxATcLQgmFxUhNRhR0RA=="
     },
     "js-yaml": {
       "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "htmlparser2": "^3.9.2",
     "jetta": "^1.1.3",
     "lodash.unescape": "^4.0.1",
-    "request": "^2.78.0",
     "valid-data-url": "^0.1.4",
     "xtend": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "faux-jax": "^5.0.5",
+    "file-url": "^2.0.2",
     "istanbul": "^0.4.5",
     "mime-types": "^2.1.12",
     "mocha": "^3.1.2"
@@ -35,6 +36,7 @@
     "chalk": "^1.1.3",
     "datauri": "^1.0.4",
     "htmlparser2": "^3.9.2",
+    "jetta": "^1.1.3",
     "lodash.unescape": "^4.0.1",
     "request": "^2.78.0",
     "valid-data-url": "^0.1.4",

--- a/src/util.js
+++ b/src/util.js
@@ -4,7 +4,7 @@ var path = require( "path" );
 var url = require( "url" );
 var datauri = require( "datauri" );
 var fs = require( "fs" );
-var request = require( "request" );
+var request = require( "jetta" ).request;
 var chalk = require( "chalk" );
 var validDataUrl = require( "valid-data-url" );
 
@@ -45,7 +45,7 @@ util.escapeSpecialChars = function( str )
 
 util.isRemotePath = function( url )
 {
-    return /^'?https?:\/\/|^\/\//.test( url );
+    return /^'?(https?|file):\/\/|^\/\//.test( url );
 };
 
 util.isBase64Path = function( url )
@@ -85,11 +85,7 @@ function getRemote( uri, settings, callback, toDataUri )
         uri = "https:" + uri;
     }
 
-    var requestOptions = {
-        uri: uri,
-        encoding: toDataUri && "binary",
-        gzip: true
-    };
+    var requestOptions = {};
 
     if( typeof settings.requestTransform === "function" )
     {
@@ -98,7 +94,7 @@ function getRemote( uri, settings, callback, toDataUri )
         {
             return callback();
         }
-        if( transformedOptions === undefined )
+        if( transformedOptions ===  undefined )
         {
             return callback( new Error( uri + " requestTransform returned `undefined`" ) );
         }
@@ -106,27 +102,28 @@ function getRemote( uri, settings, callback, toDataUri )
     }
 
     request(
+        uri,
         requestOptions,
-        function( err, response, body )
+        function( err, results )
         {
             if( err )
             {
                 return callback( err );
             }
-            else if( response.statusCode !== 200 )
+            else if( results.statusCode !== 200 && results.url.parsedURL.protocol !== "file:" )
             {
-                return callback( new Error( uri + " returned http " + response.statusCode ) );
+                return callback( new Error( uri + " returned http " + results.statusCode ) );
             }
 
             if( toDataUri )
             {
-                var b64 = new Buffer( body.toString(), "binary" ).toString( "base64" );
-                var datauriContent = "data:" + response.headers[ "content-type" ] + ";base64," + b64;
+                var b64 = new Buffer( results.data, "binary" ).toString( "base64" );
+                var datauriContent = "data:" + results.responseHeaders[ "content-type" ] + ";base64," + b64;
                 return callback( null, datauriContent );
             }
             else
             {
-                return callback( null, body );
+                return callback( null, results.data );
             }
         } );
 }

--- a/src/util.js
+++ b/src/util.js
@@ -94,7 +94,7 @@ function getRemote( uri, settings, callback, toDataUri )
         {
             return callback();
         }
-        if( transformedOptions ===  undefined )
+        if( transformedOptions === undefined )
         {
             return callback( new Error( uri + " requestTransform returned `undefined`" ) );
         }

--- a/test/cases/file-protocol.html
+++ b/test/cases/file-protocol.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>test</title>
+    <script src="%FILE_PATH%"></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/cases/file-protocol_out.html
+++ b/test/cases/file-protocol_out.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>test</title>
+    <script>
+console.log('test');
+winprint.document.write('</div></form></body></html>');
+winprint.document.write('<script>window.print();');
+winprint.document.write('<\/script>');
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/test/spec.js
+++ b/test/spec.js
@@ -591,7 +591,7 @@ describe( "html", function()
         {
             fauxJax.on( "request", function( request )
             {
-                assert( request.requestBody.indexOf('foo=bar') !== -1 );
+                assert( request.requestBody.indexOf("foo=bar") !== -1 );
             } );
             inline.html( {
                 fileContent: "<img src=\"assets/icon.png\"><img src=\"assets/icon.png?a=1\">",

--- a/test/spec.js
+++ b/test/spec.js
@@ -591,7 +591,7 @@ describe( "html", function()
         {
             fauxJax.on( "request", function( request )
             {
-                assert( request.requestBody.indexOf("foo=bar") !== -1 );
+                assert( request.requestBody.indexOf( "foo=bar" ) !== -1 );
             } );
             inline.html( {
                 fileContent: "<img src=\"assets/icon.png\"><img src=\"assets/icon.png?a=1\">",

--- a/test/spec.js
+++ b/test/spec.js
@@ -7,6 +7,7 @@ var inline = require( "../src/inline.js" );
 var util = require( "../src/util.js" );
 var fauxJax = require( "faux-jax" );
 var mime = require( "mime-types" );
+var fileUrl = require( "file-url" );
 
 function normalize( contents )
 {
@@ -57,6 +58,8 @@ function testEquality( err, result, expected, done )
 
 describe( "html", function()
 {
+    this.timeout(5000)
+
     describe( "links", function()
     {
         it( "should inline local links", function( done )
@@ -101,6 +104,24 @@ describe( "html", function()
                     testEquality( err, result, expected, done );
                 }
             );
+        } );
+
+        it( "should inline links with file:// protocol", function( done )
+        {
+            var input = readFile( "test/cases/file-protocol.html" )
+                .replace("%FILE_PATH%", fileUrl(__dirname + "/cases/assets/export.js" ) );
+
+            var expected = readFile( "test/cases/file-protocol_out.html" );
+
+            inline.html( {
+                    fileContent: input
+                },
+                function( err, result )
+                {
+                    testEquality( err, result, expected, done );
+                }
+            );
+
         } );
 
         it( "should inline remote links with no protocol", function( done )
@@ -411,7 +432,7 @@ describe( "html", function()
             },
             function( err, result )
             {
-                assert.equal( err.message, "https://raw.githubusercontent.com/not-a-file.css returned http 400" );
+                assert.equal( err.message, "Request received bad response code" );
                 done();
             }
         );
@@ -553,11 +574,24 @@ describe( "html", function()
             } );
         } );
 
+        it(" should throw an error if requestTransform function does not return in strict mode ", function ( done )
+        {
+            inline.html( {
+                fileContent: "<img src=\"assets/icon.png\"><img src=\"assets/icon.png?a=1\">",
+                relativeTo: baseUrl,
+                strict: true,
+                requestTransform: function( options ) { }
+            }, function( err, result ) {
+                assert( err.message.indexOf( "undefined" ) !== -1 );
+                done();
+            } );
+        } )
+
         it( "should apply the requestTransform option", function( done )
         {
             fauxJax.on( "request", function( request )
             {
-                assert( request.requestURL.indexOf( "foo=bar" ) !== -1 );
+                assert( request.requestBody.indexOf('foo=bar') !== -1 );
             } );
             inline.html( {
                 fileContent: "<img src=\"assets/icon.png\"><img src=\"assets/icon.png?a=1\">",
@@ -567,9 +601,11 @@ describe( "html", function()
                 images: true,
                 requestTransform: function( options )
                 {
-                    options.qs = {
+                    options.form = {
                         foo: "bar"
                     };
+
+                    return options;
                 }
             }, done );
         } );


### PR DESCRIPTION
File:// paths are perfectly [valid](https://tools.ietf.org/id/draft-kerwin-file-scheme-07.html) Unique Resource Identifiers (URIs). They are widely supported in all major browsers. As such, web-resource-inliner should support these URIs just as it supports others. Unfortunately, there are no plans for [request](https://github.com/request/request/issues/2229) to implement this protocol. [Jetta](https://github.com/AltusAero/jetta) publicly supports multiple protocols and passes all tests (with minor modifications). Therefore, I decided to replace request with Jetta.

I greatly advocate adding support for file protocols because it allows for testing directly from the file system without spawning a local file server.

My only concern is the `requestTransform` option, which is passed directly to the request client. Since the client changed, the options passed to it may not always be the same. Therefore I have two suggestions:

1) accept this PR and make it a breaking change (major version upgrade)
2) propose an alternative approach to support file: protocols (RIP this PR...)