### PR TITLE
Resolve urls in css files instead of simply joining them

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -3,6 +3,7 @@
 var xtend = require( "xtend" );
 var parallel = require( "async" ).parallel;
 var path = require( "path" );
+var url = require( "url" );
 var inline = require( "./util" );
 
 module.exports = function( options, callback )
@@ -39,7 +40,8 @@ module.exports = function( options, callback )
 
     var rebase = function( src )
     {
-        var css = "url(\"" + path.join( settings.rebaseRelativeTo, src ).replace( /\\/g, "/" ) + "\")";
+        var resolved = path.resolve( '/', settings.rebaseRelativeTo, src ).substring( 1 )
+        var css = "url(\"" + resolved.replace( /\\/g, "/" ) + "\")";
         var re = new RegExp( "url\\(\\s?[\"']?(" + inline.escapeSpecialChars( src ) + ")[\"']?\\s?\\)", "g" );
         result = result.replace( re, () => css );
     };

--- a/src/css.js
+++ b/src/css.js
@@ -3,7 +3,6 @@
 var xtend = require( "xtend" );
 var parallel = require( "async" ).parallel;
 var path = require( "path" );
-var url = require( "url" );
 var inline = require( "./util" );
 
 module.exports = function( options, callback )

--- a/src/css.js
+++ b/src/css.js
@@ -39,7 +39,7 @@ module.exports = function( options, callback )
 
     var rebase = function( src )
     {
-        var resolved = path.resolve( '/', settings.rebaseRelativeTo, src ).substring( 1 )
+        var resolved = path.resolve( '/', settings.rebaseRelativeTo, src ).substring( 1 );
         var css = "url(\"" + resolved.replace( /\\/g, "/" ) + "\")";
         var re = new RegExp( "url\\(\\s?[\"']?(" + inline.escapeSpecialChars( src ) + ")[\"']?\\s?\\)", "g" );
         result = result.replace( re, () => css );

--- a/src/html.js
+++ b/src/html.js
@@ -69,6 +69,7 @@ module.exports = function( options, callback )
         {
             if( err )
             {
+                console.log(err)
                 return inline.handleReplaceErr( err, args.src, settings.strict, callback );
             }
 

--- a/src/html.js
+++ b/src/html.js
@@ -69,7 +69,6 @@ module.exports = function( options, callback )
         {
             if( err )
             {
-                console.log(err)
                 return inline.handleReplaceErr( err, args.src, settings.strict, callback );
             }
 

--- a/test/cases/assets/css-root-path.css
+++ b/test/cases/assets/css-root-path.css
@@ -1,0 +1,3 @@
+body {
+	background: url( "/icon.png" ); /* should resolve to example.com/icon.png, NOT example.com/assets/icon.png
+}

--- a/test/cases/css-root-path.html
+++ b/test/cases/css-root-path.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>test css file using root path</title>
+    <link href="assets/css-root-path.css" rel="stylesheet">
+</head>
+<body>
+</body>
+</html>

--- a/test/spec.js
+++ b/test/spec.js
@@ -504,6 +504,30 @@ describe( "html", function()
             fauxJax.restore();
         } );
 
+        it.only( "should respect absolute root paths inside css files", function( done )
+        {
+            inline.html( {
+                fileContent: readFile( "test/cases/css-root-path.html" ),
+                relativeTo: baseUrl,
+                links: true,
+                requestTransform: function( options )
+                {
+                    if ( options.uri.indexOf('icon.png') !== -1 )
+                    {
+                        assert.equal( options.uri, baseUrl + 'icon.png' );
+                        done();
+                    }
+                    return options;
+                }
+            }, function( err, result )
+            {
+                if (err)
+                {
+                    throw err;
+                }
+            } );
+        } );
+
         it( "should use the base url (relativeTo) to resolve image URLs", function( done )
         {
             var expected = readFile( "test/cases/img_out.html" );

--- a/test/spec.js
+++ b/test/spec.js
@@ -504,7 +504,7 @@ describe( "html", function()
             fauxJax.restore();
         } );
 
-        it.only( "should respect absolute root paths inside css files", function( done )
+        it( "should respect absolute root paths inside css files", function( done )
         {
             inline.html( {
                 fileContent: readFile( "test/cases/css-root-path.html" ),


### PR DESCRIPTION
- Fixes issue described below
- Includes test case
- All tests pass

I noticed a bug where paths to resources specified in css files are resolved incorrectly when they are absolute root paths, such as `/image.png` instead of `image.png` or `./image.png`. This is because you are using `path.join` instead of `path.resolve` or `url.resolve`.[ You have to resolve paths, not join them.](https://stackoverflow.com/questions/35048686/difference-between-path-resolve-and-path-join-invocation)

Currently there is a bug in this scenario:

- basePath (relativeTo) is http://www.example.com/
- example.com/index.html has a stylesheet link at `assets/main.css`: `<link href="assets/css-root-path.css" rel="stylesheet">`
- `assets/main.css` has a background image with `url(/image.png)` (notice the prefix of `/`)

The background image is now resolved to `http://www.example.com/assets/image.png` whereas obviously it should resolve to the root domain i.e. `http://www.example.com/image.png` due to the preceding `/`.

I've resolved this in this PR. However, I am curious about your feedback on my solution for these reasons:

- I had to prepend a `/` to `path.resolve` in `css.js`, and then remove it again, to deal with the `path` library always returning absolute urls with `path.resolve`, while `css.js` is not aware of the page's root url (and therefore it expects relative urls):

```
var resolved = path.resolve( '/', settings.rebaseRelativeTo, src ).substring( 1 )
```

This works reliably, and all tests pass, but it still feels a little strange. It might be better if we don't return relative paths in `css.js` at all? Now we rebase relative paths in css.js to new relative paths, and then make them absolute in `html.js`.

- there is another call to `path.join` whereas this might have to be `path.resolve` too in `html.js` at line 89:

```
rebaseRelativeTo: path.relative( settings.relativeTo, settings.rebaseRelativeTo || path.join( settings.relativeTo, args.src, ".." + path.sep ) )
```

This line is hard for me to understand. Do you think this path.join should also be path.resolve? If so, we are missing a test case for these cases (root paths like `/img.png`), because all tests are passing atm. Generally, resolving makes more sense than joining.

So I think either we need to merge this, or we need to add more test cases if we feel like something is not entirely fixed it with this solution.

@jrit would appreciate your input. I kind of need this working asap so any input would be great.