### PR TITLE
minor patch: first check if given src is already a data uri

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -172,6 +172,10 @@ util.getFileReplacement = function( src, settings, callback )
     {
         callback( null );
     }
+    else if( validDataUrl( src ) )
+    {
+        callback( null, src );
+    }
     else if( util.isRemotePath( settings.relativeTo ) )
     {
         getRemote( url.resolve( settings.relativeTo, src ), settings, callback, true );
@@ -179,10 +183,6 @@ util.getFileReplacement = function( src, settings, callback )
     else if( util.isRemotePath( src ) )
     {
         getRemote( src, settings, callback, true );
-    }
-    else if( validDataUrl( src ) )
-    {
-        callback( null, src );
     }
     else
     {


### PR DESCRIPTION
This just makes a lot more sense, and does not affect tests. It doesn't make sense that it first checked if the settings.relativeTo is absolute, because this is not necessarily related to the given `src`. It might be that a `data:` uri source is passed while the general settings have an absolute `relativeTo` path.