### PR TITLE
(Don't merge) Inline css issue

### DIFF
--- a/test/cases/html-inline-css.html
+++ b/test/cases/html-inline-css.html
@@ -1,0 +1,1 @@
+<div style="background-image: url('assets/icon.png');"></div>

--- a/test/cases/html-inline-css_out.html
+++ b/test/cases/html-inline-css_out.html
@@ -1,0 +1,1 @@
+<div style="background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC');"></div>

--- a/test/spec.js
+++ b/test/spec.js
@@ -317,6 +317,22 @@ describe( "html", function()
                 }
             );
         } );
+
+        it( "should inline images in inline css", function( done )
+        {
+            var expected = readFile( "test/cases/html-inline-css_out.html" )
+
+            inline.html( {
+                    fileContent: readFile( "test/cases/html-inline-css.html" ),
+                    relativeTo: "test/cases",
+                    images: true
+                },
+                function( err, result )
+                {
+                    testEquality( err, result, expected, done );
+                }
+            );
+        } );
     } );
 
     describe( "svgs", function()


### PR DESCRIPTION
What better way to submit an issue than to submit a failing test case?

As illustrated, inline css is not being parsed at the moment, causing background images there to not be embedded.

How would you prefer to proceed here? Any suggestions on how this should be tackled?

**Off topic:**

P.S. I have numerous fixes lined up in other branches, but am not yet sending them because I am creating an end to end test suite with about a hundred sites to battle test this library. Once I feel like it's stable enough I will send a PR. Among others it:

1. mocks http for all tests rather than using the file system: this is necessary because http resolves differently from local file systems. E.g. if you have a domain example.com, and a path like `/image`, it should resolve to `example.com/image`, rather than resolving to the root of your file system. Only `url.resolve` can work with this, requiring you to work with an actual url rather than a file path.

2. I have moved all of your tests that require a network connection (ie make remote calls) to a separate `remote` suite; unit tests really shouldn't require an internet connection

3. properly encodes uris prior to making requests; this resolved many issues related to 404s

4. the biggest improvements are in the way resolving is done: you are resolving relative to the `baseUrl` (`relativeTo`), but this does not make sense when an external stylesheet is embedded (on another domain). I've fixed this as well.