### PR TITLE
Upgrade to async 2.6.3 to fix upstream vulnerability in lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,11 +67,18 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.14",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+        }
       }
     },
     "asynckit": {
@@ -858,7 +865,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash-compat": {
       "version": "3.10.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mocha": "^6.1.4"
   },
   "dependencies": {
-    "async": "^2.1.2",
+    "async": "^2.6.3",
     "chalk": "^1.1.3",
     "datauri": "^2.0.0",
     "htmlparser2": "^3.9.2",


### PR DESCRIPTION
There is a [new vulnerability](https://github.com/lodash/lodash/pull/4336) in `lodash` 4.17.11 ([This issue](https://github.com/lodash/lodash/issues/4348) may be related), and [`async`](https://www.npmjs.com/package/async) 2.6.3 fixes it by upgrading to 4.17.13. Seeing as `web-resource-inliner` is a dependent of `async`, could you please upgrade too?