### PR TITLE
Refactor async parallel with Promise.all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,11 +61,6 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
-    "async": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
-      "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "ansi-colors": "^4.1.1",
-    "async": "^3.1.0",
     "datauri": "^2.0.0",
     "htmlparser2": "^4.0.0",
     "lodash.unescape": "^4.0.1",

--- a/src/css.js
+++ b/src/css.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var url = require( "url" );
-var parallel = require( "async" ).parallel;
 var path = require( "path" );
 var inline = require( "./util" );
 
@@ -90,8 +89,27 @@ module.exports = function( options, callback )
         index = found.index + index + 1;
     }
 
-    parallel( tasks, function( err )
+    var promises = tasks.map( function( fn )
     {
-        callback( err, result );
+        return new Promise( function( resolve, reject )
+        {
+            fn( function( error )
+            {
+                if ( error ) {
+                    reject ( error );
+                } else {
+                    resolve();
+                }
+            } );
+        } );
     } );
+
+    Promise.all( promises )
+        .then( function()
+        {
+            callback( null, result );
+        }, function( error )
+        {
+            callback( error, result );
+        } );
 };


### PR DESCRIPTION
Ref https://github.com/jrit/web-resource-inliner/issues/58

In this diff I refactored as small as possible part of code to replace
`async.parallel` with `Promise.all` and do not introduce any breaking
changes.

Further refactoring can be made in separate PR.