### PR TITLE
Replace xtend with native Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "lodash.unescape": "^4.0.1",
     "request": "^2.88.0",
     "safer-buffer": "^2.1.2",
-    "valid-data-url": "^2.0.0",
-    "xtend": "^4.0.2"
+    "valid-data-url": "^2.0.0"
   },
   "scripts": {
     "test": "mocha test",

--- a/src/css.js
+++ b/src/css.js
@@ -1,14 +1,13 @@
 "use strict";
 
 var url = require( "url" );
-var xtend = require( "xtend" );
 var parallel = require( "async" ).parallel;
 var path = require( "path" );
 var inline = require( "./util" );
 
 module.exports = function( options, callback )
 {
-    var settings = xtend( {}, inline.defaults, options );
+    var settings = Object.assign( {}, inline.defaults, options );
 
     var replaceUrl = function( callback )
     {

--- a/src/html.js
+++ b/src/html.js
@@ -2,7 +2,6 @@
 
 var path = require( "path" );
 var unescape = require( "lodash.unescape" );
-var xtend = require( "xtend" );
 var parallel = require( "async" ).parallel;
 var inline = require( "./util" );
 var css = require( "./css" );
@@ -10,7 +9,7 @@ var htmlparser = require( "htmlparser2" );
 
 module.exports = function( options, callback )
 {
-    var settings = xtend( {}, inline.defaults, options );
+    var settings = Object.assign( {}, inline.defaults, options );
 
     function replaceInlineAttribute( string )
     {
@@ -84,7 +83,7 @@ module.exports = function( options, callback )
                     return callback( null );
                 }
 
-                var cssOptions = xtend( {}, settings, {
+                var cssOptions = Object.assign( {}, settings, {
                     fileContent: content.toString(),
                     rebaseRelativeTo: inline.isRemotePath( args.src ) && !inline.isRemotePath( settings.relativeTo ) ? args.src : path.relative( settings.relativeTo, settings.rebaseRelativeTo || path.join( settings.relativeTo, args.src, ".." + path.sep ) )
                 } );


### PR DESCRIPTION
It's supported since node v4. No need to have external dependency and no
maintenance cost.