### PR TITLE
Replace datauri with fs and mime package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,15 +123,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "datauri": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/datauri/-/datauri-2.0.0.tgz",
-      "integrity": "sha512-zS2HSf9pI5XPlNZgIqJg/wCJpecgU/HA6E/uv2EfaWnW1EiTGLfy/EexTIsC9c99yoCOTXlqeeWk4FkCSuO3/g==",
-      "requires": {
-        "image-size": "^0.7.3",
-        "mimer": "^1.0.0"
-      }
-    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -409,11 +400,6 @@
         "entities": "^2.0.0"
       }
     },
-    "image-size": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.4.tgz",
-      "integrity": "sha512-GqPgxs+VkOr12aWwjSkyRzf5atzObWpFtiRuDgxCl2I/SDpZOKZFRD3iIAeAN6/usmn8SeLWRt7a8JRYK0Whbw=="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -633,6 +619,11 @@
         }
       }
     },
+    "mime": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+    },
     "mime-db": {
       "version": "1.42.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
@@ -647,11 +638,6 @@
       "requires": {
         "mime-db": "1.42.0"
       }
-    },
-    "mimer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mimer/-/mimer-1.0.0.tgz",
-      "integrity": "sha512-4ZJvCzfcwsBgPbkKXUzGoVZMWjv8IDIygkGzVc7uUYhgnK0t2LmGxxjdgH1i+pn0/KQfB5F/VKUJlfyTSOFQjg=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "dependencies": {
     "ansi-colors": "^4.1.1",
-    "datauri": "^2.0.0",
     "htmlparser2": "^4.0.0",
     "lodash.unescape": "^4.0.1",
+    "mime": "^2.4.6",
     "node-fetch": "^2.6.0",
     "valid-data-url": "^2.0.0"
   },

--- a/src/util.js
+++ b/src/util.js
@@ -2,10 +2,10 @@
 
 var path = require( "path" );
 var url = require( "url" );
-var datauri = require( "datauri" );
 var fs = require( "fs" );
 var fetch = require( "node-fetch" );
 var colors = require( "ansi-colors" );
+var mime = require( 'mime' );
 var validDataUrl = require( "valid-data-url" );
 
 var util = {};
@@ -188,8 +188,11 @@ util.getFileReplacement = function( src, settings, callback )
     }
     else
     {
-        var result = ( new datauri( util.getInlineFilePath( src, settings.relativeTo ) ) ).content;
-        callback( result === undefined ? new Error( "Local file not found" ) : null, result );
+        var fileName = util.getInlineFilePath( src, settings.relativeTo );
+        var mimetype = mime.getType( fileName );
+        var base64 = fs.readFileSync( fileName, 'base64' );
+        var datauri = `data:${mimetype};base64,${base64}`;
+        callback( null, datauri );
     }
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -190,9 +190,10 @@ util.getFileReplacement = function( src, settings, callback )
     {
         var fileName = util.getInlineFilePath( src, settings.relativeTo );
         var mimetype = mime.getType( fileName );
-        var base64 = fs.readFileSync( fileName, 'base64' );
-        var datauri = `data:${mimetype};base64,${base64}`;
-        callback( null, datauri );
+        fs.readFile( fileName, 'base64', function( err, base64 ) {
+            var datauri = `data:${mimetype};base64,${base64}`;
+            callback( err, datauri );
+        } );
     }
 };
 


### PR DESCRIPTION
The new version of datauri has quite a load of dependencies
for features which are not in this package.

https://packagephobia.com/result?p=datauri

In this diff I replaced it with more popular `mime` package (than datauri's
mimer) and builtin fs read with base64 encoding.

https://packagephobia.com/result?p=mime