### PR TITLE
Replace lodash.unescape with escape-goat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -231,6 +231,11 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "escape-goat": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
+      "integrity": "sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -552,11 +557,6 @@
       "resolved": "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.10.2.tgz",
       "integrity": "sha1-xpQBKKnTD46QLNLPmf0Muk7PwYM=",
       "dev": true
-    },
-    "lodash.unescape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "ansi-colors": "^4.1.1",
+    "escape-goat": "^3.0.0",
     "htmlparser2": "^4.0.0",
-    "lodash.unescape": "^4.0.1",
     "mime": "^2.4.6",
     "node-fetch": "^2.6.0",
     "valid-data-url": "^2.0.0"

--- a/src/html.js
+++ b/src/html.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var path = require( "path" );
-var unescape = require( "lodash.unescape" );
+var { htmlUnescape } = require( "escape-goat" );
 var inline = require( "./util" );
 var css = require( "./css" );
 var htmlparser = require( "htmlparser2" );
@@ -187,7 +187,7 @@ module.exports = function( options, callback )
         if( !inlineAttributeIgnoreRegex.test( found[ 0 ] ) &&
             ( settings.scripts || inlineAttributeRegex.test( found[ 0 ] ) ) )
         {
-            var src = unescape( found[ 2 ] ).trim();
+            var src = htmlUnescape( found[ 2 ] ).trim();
             if ( src && src.indexOf( "#" ) !== 0 )
             {
                 tasks.push( replaceScript.bind(
@@ -208,7 +208,7 @@ module.exports = function( options, callback )
             relStylesheetAttributeIgnoreRegex.test( found[ 0 ] ) &&
             ( settings.links || inlineAttributeRegex.test( found[ 0 ] ) ) )
         {
-            var src = unescape( found[ 2 ] ).trim();
+            var src = htmlUnescape( found[ 2 ] ).trim();
             if ( src && src.indexOf( "#" ) !== 0 )
             {
                 tasks.push( replaceLink.bind(
@@ -228,7 +228,7 @@ module.exports = function( options, callback )
         if( !inlineAttributeIgnoreRegex.test( found[ 0 ] ) &&
             ( settings.images || inlineAttributeRegex.test( found[ 0 ] ) ) )
         {
-            var src = unescape( found[ 2 ] ).trim();
+            var src = htmlUnescape( found[ 2 ] ).trim();
             if ( src && src.indexOf( "#" ) !== 0 ) {
                 tasks.push( replaceImg.bind(
                 {
@@ -250,10 +250,10 @@ module.exports = function( options, callback )
             tasks.push( replaceSvg.bind(
             {
                 element: found[ 0 ],
-                src: unescape( found[ 2 ] ).trim(),
+                src: htmlUnescape( found[ 2 ] ).trim(),
                 attrs: inline.getAttrs( found[ 0 ], settings ),
                 limit: settings.svgs,
-                id: unescape( found[ 3 ] ).trim()
+                id: htmlUnescape( found[ 3 ] ).trim()
             } ) );
         }
     }


### PR DESCRIPTION
Lodash per function packages are deprecated and will be removed in v5.
It's a good reason to use small isolated module instead of large package.

Note: escape-goat requires node v10