### PR TITLE
Feat: add support for @import CSS-rule

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -36,6 +36,54 @@ module.exports = function( options, callback )
         } );
     };
 
+    var replaceImport = function( callback )
+    {
+        var args = this;
+
+        if( inline.isBase64Path( args.src ) )
+        {
+            return callback( null ); // Skip
+        }
+
+        inline.getTextReplacement( args.src, settings, function( err, content )
+        {
+            if( err )
+            {
+                return inline.handleReplaceErr( err, args.src, settings.strict, callback );
+            }
+
+            var onTransform = function( err, content )
+            {
+                if( err )
+                {
+                    return callback( err );
+                }
+
+                var rule = inline.parseCSSImportRule( args.rule );
+                var css = content.toString();
+                if( rule.media )
+                {
+                    css = "@media " + rule.media + " {\n" + css + "}\n";
+                }
+                if( rule.supports )
+                {
+                    css = "@supports (" + rule.supports + ") {\n" + css + "}\n";
+                }
+                if( rule.layer )
+                {
+                    css = "@layer " + ( typeof( rule.layer ) === "string" ? rule.layer : "" ) + " {\n" + css + "}\n";
+                }
+                var re = new RegExp( inline.escapeSpecialChars( args.marker ), "g" );
+                result = result.replace( re, () => css );
+
+                return callback( null );
+            };
+
+            // recursively process imported CSS
+            module.exports( Object.assign( {}, settings, { fileContent: content.toString() } ), onTransform );
+        } );
+    };
+
     var rebase = function( src )
     {
         var css = "url(\"" + ( inline.isRemotePath( src ) || inline.isRemotePath( settings.rebaseRelativeTo ) ? url.resolve( settings.rebaseRelativeTo, src ) : path.join( settings.rebaseRelativeTo, src ).replace( /\\/g, "/" ) ) + "\")";
@@ -73,6 +121,28 @@ module.exports = function( options, callback )
 
     var inlineAttributeCommentRegex = new RegExp( "\\/\\*\\s?" + settings.inlineAttribute + "\\s?\\*\\/", "i" );
     var inlineAttributeIgnoreCommentRegex = new RegExp( "\\/\\*\\s?" + settings.inlineAttribute + "-ignore\\s?\\*\\/", "i" );
+
+    index = 0;
+    while( ( found = inline.CSSImportRegex.exec( result.substring( index ) ) ) !== null )
+    {
+        if( !inlineAttributeIgnoreCommentRegex.test( found[ 0 ] ) &&
+            ( settings.imports || inlineAttributeCommentRegex.test( found[ 0 ] ) ) )
+        {
+            var injectMarker = "/* @@inline-" + Math.floor( 10000 + Math.random() * 10000 ) + "@@ */";
+            var re = new RegExp( inline.escapeSpecialChars( found[ 0 ] ), "g" );
+            result = result.replace( re, injectMarker ); // replace rule immediately to prevent inlining by parallel tasks
+            tasks.push( replaceImport.bind(
+                {
+                    rule: found[ 0 ],
+                    src: found.groups.url,
+                    marker: injectMarker
+                } ) );
+        }
+        else
+        {
+            index = found.index + index + 1;
+        }
+    }
 
     index = 0;
     while( ( found = urlRegex.exec( result.substring( index ) ) ) !== null )

--- a/src/css.js
+++ b/src/css.js
@@ -64,15 +64,15 @@ module.exports = function( options, callback )
 
                 var rule = inline.parseCSSImportRule( args.rule );
                 var css = content.toString();
-                if( rule.media )
+                if( rule?.media )
                 {
                     css = "@media " + rule.media + " {\n" + css + "}\n";
                 }
-                if( rule.supports )
+                if( rule?.supports )
                 {
                     css = "@supports (" + rule.supports + ") {\n" + css + "}\n";
                 }
-                if( rule.layer )
+                if( rule?.layer )
                 {
                     css = "@layer " + ( typeof( rule.layer ) === "string" ? rule.layer : "" ) + " {\n" + css + "}\n";
                 }
@@ -136,7 +136,7 @@ module.exports = function( options, callback )
             tasks.push( replaceImport.bind(
                 {
                     rule: found[ 0 ],
-                    src: found.groups.url,
+                    src: found.groups.url || found.groups.url2,
                     marker: injectMarker
                 } ) );
         }

--- a/src/css.js
+++ b/src/css.js
@@ -39,9 +39,11 @@ module.exports = function( options, callback )
     var replaceImport = function( callback )
     {
         var args = this;
+        var re = new RegExp( inline.escapeSpecialChars( args.marker ), "g" );
 
         if( inline.isBase64Path( args.src ) )
         {
+            result = result.replace( re, () => args.rule );
             return callback( null ); // Skip
         }
 
@@ -49,6 +51,7 @@ module.exports = function( options, callback )
         {
             if( err )
             {
+                result = result.replace( re, () => args.rule );
                 return inline.handleReplaceErr( err, args.src, settings.strict, callback );
             }
 
@@ -73,7 +76,6 @@ module.exports = function( options, callback )
                 {
                     css = "@layer " + ( typeof( rule.layer ) === "string" ? rule.layer : "" ) + " {\n" + css + "}\n";
                 }
-                var re = new RegExp( inline.escapeSpecialChars( args.marker ), "g" );
                 result = result.replace( re, () => css );
 
                 return callback( null );

--- a/src/html.js
+++ b/src/html.js
@@ -149,7 +149,7 @@ module.exports = function( options, callback )
         {
             return options.styleTransform( args.src, onTransform );
         }
-        onTransform(null, args.src );
+        onTransform( null, args.src );
     };
 
     var replaceImg = function( callback )
@@ -264,7 +264,7 @@ module.exports = function( options, callback )
         }
     }
 
-    var styleRegex = /<style\b[\s\S]+?(?:\btype\s*=\s*("|')text\/css\1)?[\s\S]*?>([\s\S]*?)<\/style>/gm
+    var styleRegex = /<style\b[\s\S]+?(?:\btype\s*=\s*("|')text\/css\1)?[\s\S]*?>([\s\S]*?)<\/style>/gm;
     while( ( found = styleRegex.exec( result ) ) !== null )
     {
         if( !inlineAttributeIgnoreRegex.test( found[ 0 ] ) &&

--- a/src/util.js
+++ b/src/util.js
@@ -29,7 +29,7 @@ util.defaults = {
 
 util.attrValueExpression = "(=[\"']([^\"']+?)[\"'])?";
 util.CSSImportRegex = new RegExp(
-    '@import\\s+(?<urlExpr>(["\'])(?<url>.+?)(?<!\\\\)\\2|(?:src|url)\\(\\s*(["\'])(?<url>.+?)(?<!\\\\)\\4\\s*\\))(?<rest>[^;]*);.*$',
+    '@import\\s+(?<urlExpr>(["\'])(?<url>.+?)(?<!\\\\)\\2|(?:src|url)\\(\\s*(["\'])(?<url2>.+?)(?<!\\\\)\\4\\s*\\))(?<rest>[^;]*);.*$',
     "im"
 );
 
@@ -271,7 +271,7 @@ util.parseCSSImportRule = function( rule )
 {
     var matches = util.CSSImportRegex.exec( rule );
 
-    if( !matches || !matches.groups.url )
+    if( !matches || ( !matches.groups.url && !matches.groups.url2 ) )
     {
         return null;
     }
@@ -303,7 +303,7 @@ util.parseCSSImportRule = function( rule )
     var media = rest.replace( /\s*;.*$/m, "" ).trim();
 
     return {
-        url: matches.groups.url,
+        url: matches.groups.url || matches.groups.url2,
         layer: layer || null,
         supports: supports || null,
         media: media || null

--- a/src/util.js
+++ b/src/util.js
@@ -79,6 +79,10 @@ util.getAttrs = function( tagMarkup, settings )
         {
             return attrs.replace( /(href|rel)=["'][^"']*["']/g, "" ).trim();
         }
+        else if( tag === "<style" )
+        {
+            return attrs.trim();
+        }
     }
 };
 

--- a/test/cases/css-import-advanced.css
+++ b/test/cases/css-import-advanced.css
@@ -1,0 +1,15 @@
+/* media queries */
+@import url("css.css") print and (max-width: 800px);
+/* layers */
+@import url("css.css") layer;
+@import url("css.css") layer(utilities);
+/* feature detection */
+@import url("css.css") supports(display: grid);
+@import url("css.css") supports((not (display: grid)) and (display: flex));
+/* all together */
+@import url("css.css")
+    layer(base)
+    supports(display: grid)
+    screen and (max-width: 800px);
+
+/* more styles */

--- a/test/cases/css-import-advanced_out.css
+++ b/test/cases/css-import-advanced_out.css
@@ -1,0 +1,70 @@
+/* media queries */
+@media print and (max-width: 800px) {
+body {
+	background: url(assets/other.png);
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC");/*data-inline*/  
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC"); /* data-inline */
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC"); /* data-inline */
+	background: url("data:image/png;base64,SKIP"); /* data-inline */
+}
+}
+
+/* layers */
+@layer  {
+body {
+	background: url(assets/other.png);
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC");/*data-inline*/  
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC"); /* data-inline */
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC"); /* data-inline */
+	background: url("data:image/png;base64,SKIP"); /* data-inline */
+}
+}
+
+@layer utilities {
+body {
+	background: url(assets/other.png);
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC");/*data-inline*/  
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC"); /* data-inline */
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC"); /* data-inline */
+	background: url("data:image/png;base64,SKIP"); /* data-inline */
+}
+}
+
+/* feature detection */
+@supports (display: grid) {
+body {
+	background: url(assets/other.png);
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC");/*data-inline*/  
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC"); /* data-inline */
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC"); /* data-inline */
+	background: url("data:image/png;base64,SKIP"); /* data-inline */
+}
+}
+
+@supports ((not (display: grid)) and (display: flex)) {
+body {
+	background: url(assets/other.png);
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC");/*data-inline*/  
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC"); /* data-inline */
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC"); /* data-inline */
+	background: url("data:image/png;base64,SKIP"); /* data-inline */
+}
+}
+
+/* all together */
+@layer base {
+@supports (display: grid) {
+@media screen and (max-width: 800px) {
+body {
+	background: url(assets/other.png);
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC");/*data-inline*/  
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC"); /* data-inline */
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC"); /* data-inline */
+	background: url("data:image/png;base64,SKIP"); /* data-inline */
+}
+}
+}
+}
+
+
+/* more styles */

--- a/test/cases/css-import.css
+++ b/test/cases/css-import.css
@@ -1,0 +1,3 @@
+@import url("css-remote.css");
+
+/* more styles */

--- a/test/cases/css-import.html
+++ b/test/cases/css-import.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>test</title>
+    <style type="text/css">
+    @import url("css-remote.css");
+
+    /* more styles */
+
+    </style>
+</head>
+<body>
+</body>
+</html>

--- a/test/cases/css-import_out.css
+++ b/test/cases/css-import_out.css
@@ -1,0 +1,6 @@
+body {
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC");
+}
+
+
+/* more styles */

--- a/test/cases/css-import_out.html
+++ b/test/cases/css-import_out.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>test</title>
+    <style type="text/css">
+    body {
+	background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVQoz2NgAIP/YMBAPBjVMNAa/pMISNcwEoMVAH0ls03D44ABAAAAAElFTkSuQmCC");
+}
+
+
+    /* more styles */
+
+    </style>
+</head>
+<body>
+</body>
+</html>

--- a/test/spec.js
+++ b/test/spec.js
@@ -665,6 +665,72 @@ describe( "css", function()
         );
     } );
 
+    it( "should inline @import rule (basic)", function( done )
+    {
+        var expected = readFile( "test/cases/css-import_out.css" );
+
+        inline.css( {
+                fileContent: readFile( "test/cases/css-import.css" ),
+                relativeTo: "test/cases/",
+                imports: true
+            },
+            function( err, result )
+            {
+                testEquality( err, result, expected, done );
+            }
+        );
+    } );
+
+    it( "should inline @import rule included via comment", function( done )
+    {
+        var expected = readFile( "test/cases/css-import_out.css" );
+
+        inline.css( {
+                fileContent: readFile( "test/cases/css-import.css" )
+                    .replace(/@import.+$/im, '$& /* data-inline */'),
+                relativeTo: "test/cases/",
+                imports: false
+            },
+            function( err, result )
+            {
+                testEquality( err, result, expected, done );
+            }
+        );
+    } );
+
+    it( "should not inline @import rule excluded via comment", function( done )
+    {
+        var expected = readFile( "test/cases/css-import.css" )
+            .replace(/@import.+$/im, '$& /* data-inline-ignore */');
+
+        inline.css( {
+                fileContent: expected,
+                relativeTo: "test/cases/",
+                imports: true
+            },
+            function( err, result )
+            {
+                testEquality( err, result, expected, done );
+            }
+        );
+    } );
+
+    it( "should inline @import rule (advanced)", function( done )
+    {
+        var expected = readFile( "test/cases/css-import-advanced_out.css" );
+
+        inline.css( {
+                fileContent: readFile( "test/cases/css-import-advanced.css" ),
+                relativeTo: "test/cases/",
+                imports: true
+            },
+            function( err, result )
+            {
+                testEquality( err, result, expected, done );
+            }
+        );
+    } );
+
     it( "should rebase local urls", function( done )
     {
         var expected = readFile( "test/cases/css-rebase_out.css" );
@@ -699,6 +765,124 @@ describe( "util", function()
             assert.equal( result, expected );
             assert.equal( str.match( regex ).length, 1 );
 
+        } );
+    } );
+
+    describe( "#parseCSSImportRule", function()
+    {
+        it( "should parse basic @import rule", function()
+        {
+            var testCases = [
+                [ '@import "styles.css";', "styles.css" ],
+                [ '@import "styles\\".css";', 'styles\\".css' ],
+                [ "@import 'styles.css';", "styles.css" ],
+                [ '@import url( "styles.css?query=param&a=b&foo[]=bar" ) ;', "styles.css?query=param&a=b&foo[]=bar" ],
+                [ '\n@import\nurl(\n"styles.css"\n)\n;\n', "styles.css" ]
+            ];
+
+            testCases.forEach( function( testCase, idx )
+            {
+                assert.deepStrictEqual( util.parseCSSImportRule( testCase[ 0 ] ), {
+                    url: testCase[ 1 ],
+                    layer: null,
+                    supports: null,
+                    media: null
+                }, "Test case #" + idx + " failed." );
+            } );
+        } );
+
+        it( "should parse @import rule with media queries", function()
+        {
+            var testCases = [
+                '@import "styles.css" screen and (orientation: landscape);',
+                '@import url( "styles.css" ) screen and (orientation: landscape);'
+            ];
+
+            testCases.forEach( function( testCase, idx )
+            {
+                assert.deepStrictEqual( util.parseCSSImportRule( testCase ), {
+                    url: "styles.css",
+                    layer: null,
+                    supports: null,
+                    media: "screen and (orientation: landscape)"
+                }, "Test case #" + idx + " failed." );
+            } );
+        } );
+
+        it( "should parse @import rule with a cascade layer", function()
+        {
+            var testCases = [
+                [ '@import "styles.css" layer(utilities);', "utilities" ],
+                [ '@import url("styles.css") layer;', true ],
+                [ '@import url( "styles.css" ) layer();', true ]
+            ];
+
+            testCases.forEach( function( testCase, idx )
+            {
+                assert.deepStrictEqual( util.parseCSSImportRule( testCase[ 0 ] ), {
+                    url: "styles.css",
+                    layer: testCase[ 1 ],
+                    supports: null,
+                    media: null
+                }, "Test case #" + idx + " failed." );
+            } );
+        } );
+
+        it( "should parse @import rule with a cascade layer and media queries", function()
+        {
+            var testCases = [
+                [ '@import "styles.css" layer(utilities) screen and (orientation: landscape) ;', "utilities" ],
+                [ '@import url("styles.css") layer screen and (orientation: landscape);', true ],
+                [ '@import url( "styles.css" ) layer() screen and (orientation: landscape) ;', true ]
+            ];
+
+            testCases.forEach( function( testCase, idx )
+            {
+                assert.deepStrictEqual( util.parseCSSImportRule( testCase[ 0 ] ), {
+                    url: "styles.css",
+                    layer: testCase[ 1 ],
+                    supports: null,
+                    media: "screen and (orientation: landscape)"
+                }, "Test case #" + idx + " failed." );
+            } );
+        } );
+
+        it( "should parse @import rule with feature conditional", function()
+        {
+            var testCases = [
+                [ '@import "styles.css" supports(display: grid);', "display: grid" ],
+                [ '@import url("styles.css") supports( (not (display: grid))\n and\n (display: flex) ) ;', "(not (display: grid))\n and\n (display: flex)" ],
+                [ '@import url( "styles.css" )\nsupports((selector(h2 > p)) and (font-tech(color-COLRv1)));', "(selector(h2 > p)) and (font-tech(color-COLRv1))" ]
+            ];
+
+            testCases.forEach( function( testCase, idx )
+            {
+                assert.deepStrictEqual( util.parseCSSImportRule( testCase[ 0 ] ), {
+                    url: "styles.css",
+                    layer: null,
+                    supports: testCase[ 1 ],
+                    media: null
+                }, "Test case #" + idx + " failed." );
+            } );
+        } );
+
+        it( "should parse @import rule with all options used", function()
+        {
+            var testCases = [
+                [ '@import "styles.css" layer supports(display: grid);', true, "display: grid", null ],
+                [ '@import url("styles.css") layer(utilities) supports( (not (display: grid))\n and\n (display: flex) ) ;', "utilities", "(not (display: grid))\n and\n (display: flex)", null ],
+                [ '@import url( "styles.css" )\nlayer()\nsupports((selector(h2 > p)) and (font-tech(color-COLRv1)))\nscreen, print and (max-width: 800px);', true, "(selector(h2 > p)) and (font-tech(color-COLRv1))", "screen, print and (max-width: 800px)" ]
+            ];
+
+            testCases.forEach( function( testCase, idx )
+            {
+                assert.deepStrictEqual( util.parseCSSImportRule( testCase[ 0 ] ), {
+                    url: "styles.css",
+                    layer: testCase[ 1 ],
+                    supports: testCase[ 2 ],
+                    media: testCase[ 3 ]
+                }, "Test case #" + idx + " failed." );
+            } );
         } );
     } );
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -189,6 +189,25 @@ describe( "html", function()
 
     } );
 
+    describe( "css imports", function()
+    {
+        it( "should inline @import rules inside stylesheets", function( done )
+        {
+            var expected = readFile( "test/cases/css-import_out.html" );
+
+            inline.html( {
+                    fileContent: readFile( "test/cases/css-import.html" ),
+                    relativeTo: "test/cases/",
+                    imports: true
+                },
+                function( err, result )
+                {
+                    testEquality( err, result, expected, done );
+                }
+            );
+        } );
+    } );
+
     describe( "scripts", function()
     {
         it( "should inline scripts", function( done )


### PR DESCRIPTION
Added support for `@import` css-rule. It can help with inlining imported stylesheets such as Google Fonts.

The feature is disabled by default but can be enabled using the `imports: true` option.

Example:
```js
css(
  {
    fileContent: '@import url('https://fonts.googleapis.com/css2?family=Open+Sans&display=swap')',
    imports: true
  }, 
  (err, content) => console.log(content)
)
```
Output:
```css
@font-face {
  font-family: 'Open Sans';
  font-style: normal;
  font-weight: 400;
  font-stretch: 100%;
  font-display: swap;
  src: url("data:font/woff2;base64,...) format('woff2');
}
...
```

Without `imports: true` the output will be:
```css
@import url('data::text/css; charset=utf-8;base64,...');
```